### PR TITLE
fix: build error

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+python-greenlet (3.0.1-3deepin2) unstable; urgency=medium
+
+  * fix build setup() error.
+
+ -- lichenggang <lichenggang@deepin.org>  Tue, 22 Jul 2025 19:25:05 +0800
+
 python-greenlet (3.0.1-3deepin1) unstable; urgency=medium
 
   * feat: add sw64 support.

--- a/debian/patches/fix-build-conf.patch
+++ b/debian/patches/fix-build-conf.patch
@@ -1,0 +1,22 @@
+--- python-greenlet-3.0.1.orig/docs/conf.py
++++ python-greenlet-3.0.1/docs/conf.py
+@@ -41,7 +41,7 @@ extensions = [
+ templates_path = []  # ['_templates']
+ 
+ # The suffix of source filenames.
+-source_suffix = '.rst'
++source_suffix = {'.rst': 'restructuredtext'}
+ 
+ # The encoding of source files.
+ #source_encoding = 'utf-8-sig'
+@@ -252,8 +252,8 @@ texinfo_documents = [
+ #texinfo_show_urls = 'footnote'
+ 
+ intersphinx_mapping = {
+-    'https://docs.python.org/': None,
+-    'https://www.gevent.org/': None,
++    'python': ('https://docs.python.org/3/', None),
++    'gevent': ('https://www.gevent.org/', None),
+ }
+ 
+ 

--- a/debian/patches/fix-build-setup-error.patch
+++ b/debian/patches/fix-build-setup-error.patch
@@ -1,0 +1,16 @@
+--- python-greenlet-3.0.1.orig/setup.py
++++ python-greenlet-3.0.1/setup.py
+@@ -116,10 +116,11 @@ def readfile(filename):
+ def abspath(rel):
+     return os.path.join(os.path.dirname(__file__), rel)
+ 
+-GREENLET_SRC_DIR = abspath('src/greenlet/')
++# Use relative paths for setuptools - absolute paths cause build errors
++GREENLET_SRC_DIR = 'src/greenlet/'
+ GREENLET_HEADER_DIR = GREENLET_SRC_DIR
+ GREENLET_HEADER = GREENLET_HEADER_DIR + 'greenlet.h'
+-GREENLET_TEST_DIR = abspath('src/greenlet/tests/')
++GREENLET_TEST_DIR = 'src/greenlet/tests/'
+ # The location of the platform specific assembly files
+ # for switching.
+ GREENLET_PLATFORM_DIR = GREENLET_SRC_DIR + 'platform/'

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,3 +1,5 @@
 setup-use-absolute-paths.patch
 arm32-tests.patch
 0001-deepin-sw64-support.diff
+fix-build-setup-error.patch
+fix-build-conf.patch


### PR DESCRIPTION
  setup() arguments must *always* be /-separated paths relative to the setup.py directory, *never* absolute path